### PR TITLE
DNM - Added topic-based pub/sub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/filipdulic/bus-queue"
 readme = "README.md"
 
 [dependencies]
-lockfree = "^0.5.1"
+lockfree = {version = "^0.5.1", optional = true}
 arc-swap = "0.3.6"
 futures = {version = "0.1", optional = true}
 tokio = {version = "0.1", optional = true}
@@ -17,7 +17,9 @@ tokio = {version = "0.1", optional = true}
 [features]
 default = ["async"]
 async = ["futures"]
+sync = ["lockfree"]
 async-example = ["tokio"]
+
 
 [[example]]
 name = "bare-simple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,15 @@ repository = "https://github.com/filipdulic/bus-queue"
 readme = "README.md"
 
 [dependencies]
-lockfree = {version = "^0.5.1", optional = true}
 arc-swap = "0.3.6"
 futures = {version = "0.1", optional = true}
-tokio = {version = "0.1", optional = true}
+
+[dev-dependencies]
+tokio = "0.1"
 
 [features]
 default = ["async"]
 async = ["futures"]
-sync = ["lockfree"]
-async-example = ["tokio"]
-
 
 [[example]]
 name = "bare-simple"

--- a/src/async_.rs
+++ b/src/async_.rs
@@ -32,7 +32,6 @@ impl<T: Send> Sink for Publisher<T> {
     }
 
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        futures::task::current().notify();
         Ok(Async::Ready(()))
     }
 

--- a/src/async_pubsub.rs
+++ b/src/async_pubsub.rs
@@ -12,11 +12,11 @@ pub fn channel<T: Send>(size: usize) -> (TopicPublisher<T>, TopicSubscriber<T>) 
 
 pub struct TopicPayload<T> {
     topic: T,
-    message: Box<dyn Any + Send>,
+    message: Box<dyn Any + Send + Sync>,
 }
 
 impl<T> TopicPayload<T> {
-    pub fn new<M: Any + Send>(topic: T, message: M) -> Self {
+    pub fn new<M: Any + Send + Sync>(topic: T, message: M) -> Self {
         Self {
             topic,
             message: Box::new(message),

--- a/src/async_pubsub.rs
+++ b/src/async_pubsub.rs
@@ -1,0 +1,147 @@
+use super::async_::channel as async_channel;
+use super::async_::Publisher;
+use super::async_::Subscriber;
+use futures::{Async, Poll, Stream};
+use std::any::Any;
+use std::marker::PhantomData;
+
+pub fn channel<T: Send>(size: usize) -> (TopicPublisher<T>, TopicSubscriber<T>) {
+    let (publisher, subscriber) = async_channel(size);
+    (publisher, TopicSubscriber::new(subscriber))
+}
+
+pub struct TopicPayload<T> {
+    topic: T,
+    message: Box<dyn Any + Send>,
+}
+
+impl<T> TopicPayload<T> {
+    fn new<M: Any + Send>(topic: T, message: M) -> Self {
+        Self {
+            topic,
+            message: Box::new(message),
+        }
+    }
+
+    fn downcast_cloned<U>(&self) -> Option<U>
+    where
+        U: Clone + 'static,
+    {
+        self.message.downcast_ref::<U>().map(Clone::clone)
+    }
+}
+
+type TopicPublisher<T> = Publisher<TopicPayload<T>>;
+
+pub struct TopicSubscriber<T: Send> {
+    inner: Subscriber<TopicPayload<T>>,
+}
+
+impl<T: Send> TopicSubscriber<T> {
+    fn new(subscriber: Subscriber<TopicPayload<T>>) -> Self {
+        Self { inner: subscriber }
+    }
+}
+
+impl<T: Eq + Send> TopicSubscriber<T> {
+    pub fn subscription<M>(&self, topic: T) -> TopicSubscription<T, M> {
+        TopicSubscription::<_, M>::new(topic, self.inner.clone())
+    }
+}
+
+pub struct TopicSubscription<T: Send, M> {
+    topic: T,
+    inner: Subscriber<TopicPayload<T>>,
+    _m: PhantomData<M>,
+}
+
+impl<T: Eq + Send, M> TopicSubscription<T, M> {
+    fn new(topic: T, subscriber: Subscriber<TopicPayload<T>>) -> Self {
+        Self {
+            topic,
+            inner: subscriber,
+            _m: PhantomData,
+        }
+    }
+}
+
+impl<T, M> Stream for TopicSubscription<T, M>
+where
+    T: Eq,
+    T: Send,
+    M: Clone,
+    M: 'static,
+{
+    type Item = M;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            match try_ready!(self.inner.poll()) {
+                Some(payload) => {
+                    if payload.topic == self.topic {
+                        let message = payload.downcast_cloned::<M>().ok_or(())?;
+                        return Ok(Async::Ready(Some(message)));
+                    }
+                }
+                None => return Ok(Async::Ready(None)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::stream;
+    use futures::Future;
+    use futures::Sink;
+    use std::sync::Arc;
+    use tokio::runtime::current_thread::Runtime;
+
+    #[test]
+    fn async_pubsub() {
+        let mut rt = Runtime::new().unwrap();
+        let (publisher, subscriber) = channel(10);
+        #[derive(Clone)]
+        struct Dummy {
+            a: u32,
+        }
+
+        let messages = vec![
+            TopicPayload::new("numbers", 1u32),
+            TopicPayload::new("strings", "FIRST"),
+            TopicPayload::new("strings", "SECOND"),
+            TopicPayload::new("strings", "THIRD"),
+            TopicPayload::new("strings", "FOURTH"),
+            TopicPayload::new("numbers", 2u32),
+            TopicPayload::new("structs", Arc::new(Dummy { a: 123 })),
+        ];
+        let pub_task = stream::iter_ok(messages)
+            .forward(publisher)
+            .and_then(|(_, mut sink)| sink.close())
+            .map(|_| ())
+            .map_err(|_| ());
+
+        rt.spawn(pub_task);
+
+        let sub1 = subscriber.subscription("numbers");
+        let numbers: Vec<u32> = rt.block_on(sub1.collect()).unwrap();
+        assert_eq!(numbers.len(), 2);
+        assert_eq!(numbers[0], 1);
+        assert_eq!(numbers[1], 2);
+
+        let sub2 = subscriber.subscription::<&str>("strings");
+        let strings: Vec<_> = rt.block_on(sub2.collect()).unwrap();
+        assert_eq!(strings.len(), 4);
+        assert_eq!(strings[0], "FIRST");
+        assert_eq!(strings[1], "SECOND");
+        assert_eq!(strings[2], "THIRD");
+        assert_eq!(strings[3], "FOURTH");
+
+        let sub2 = subscriber.subscription("structs");
+        let structs: Vec<Arc<Dummy>> = rt.block_on(sub2.collect()).unwrap();
+        assert_eq!(structs.len(), 1);
+        assert_eq!(structs[0].a, 123);
+    }
+}

--- a/src/async_pubsub.rs
+++ b/src/async_pubsub.rs
@@ -16,14 +16,14 @@ pub struct TopicPayload<T> {
 }
 
 impl<T> TopicPayload<T> {
-    fn new<M: Any + Send>(topic: T, message: M) -> Self {
+    pub fn new<M: Any + Send>(topic: T, message: M) -> Self {
         Self {
             topic,
             message: Box::new(message),
         }
     }
 
-    fn downcast_cloned<U>(&self) -> Option<U>
+    pub fn downcast_cloned<U>(&self) -> Option<U>
     where
         U: Clone + 'static,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,7 @@ pub mod async_pubsub;
 )]
 pub mod async {
     pub use super::async_::*;
+    pub use super::async_pubsub::*;
 }
 #[cfg(test)]
 extern crate tokio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! use bus_queue::async_;
 //! use futures::*;
-//! use tokio::runtime::Runtime;
+//! use tokio::runtime::current_thread::Runtime;
 //!
 //! fn main() {
 //!     let mut rt = Runtime::new().unwrap();
@@ -328,52 +328,6 @@ impl<T: Send> Iterator for BareSubscriber<T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.try_recv().ok()
     }
-}
-
-/// Helper struct used by sync and async implementations to wake Tasks / Threads
-#[derive(Debug)]
-pub struct Waker<T> {
-    /// Vector of Tasks / Threads to be woken up.
-    pub sleepers: Vec<Arc<T>>,
-    /// A mpsc Receiver used to receive Tasks / Threads to be registered.
-    receiver: lockfree::channel::mpsc::Receiver<Arc<T>>,
-}
-
-/// Helper struct used by sync and async implementations to register Tasks / Threads to
-/// be woken up.
-#[derive(Debug)]
-pub struct Sleeper<T> {
-    /// Current Task / Thread to be woken up.
-    pub sleeper: Arc<T>,
-    /// mpsc Sender used to register Task / Thread.
-    pub sender: lockfree::channel::mpsc::Sender<Arc<T>>,
-}
-
-impl<T> Waker<T> {
-    /// Register all the Tasks / Threads sent for registration.
-    pub fn register_receivers(&mut self) {
-        for receiver in self.receiver.recv() {
-            self.sleepers.push(receiver);
-        }
-    }
-}
-
-/// Function used to create a ( Waker, Sleeper ) tuple.
-pub fn alarm<T>(current: T) -> (Waker<T>, Sleeper<T>) {
-    let mut vec = Vec::new();
-    let (sender, receiver) = lockfree::channel::mpsc::create();
-    let arc_t = Arc::new(current);
-    vec.push(arc_t.clone());
-    (
-        Waker {
-            sleepers: vec,
-            receiver,
-        },
-        Sleeper {
-            sleeper: arc_t,
-            sender,
-        },
-    )
 }
 
 pub mod sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,6 @@ impl<T: Send> BarePublisher<T> {
     /// Publishes values to the circular buffer at wi % size
     /// # Arguments
     /// * `object` - owned object to be published
-
     pub fn broadcast(&self, object: T) -> Result<(), SendError<T>> {
         if self.sub_cnt.get() == 0 {
             return Err(SendError(object));
@@ -377,9 +376,12 @@ pub fn alarm<T>(current: T) -> (Waker<T>, Sleeper<T>) {
 
 pub mod sync;
 #[cfg(feature = "async")]
+#[macro_use]
 extern crate futures;
 #[cfg(feature = "async")]
 pub mod async_;
+#[cfg(feature = "async")]
+pub mod async_pubsub;
 #[cfg(feature = "async")]
 #[deprecated(
     since = "0.3.8",

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -152,3 +152,58 @@ impl<T: Send> PartialEq for Subscriber<T> {
 }
 
 impl<T: Send> Eq for Subscriber<T> {}
+
+/// Helper struct used by sync and async implementations to wake Tasks / Threads
+#[derive(Debug)]
+pub struct Waker<T> {
+    /// Vector of Tasks / Threads to be woken up.
+    pub sleepers: Vec<Arc<T>>,
+    /// A mpsc Receiver used to receive Tasks / Threads to be registered.
+    receiver: lockfree::channel::mpsc::Receiver<Arc<T>>,
+}
+
+/// Helper struct used by sync and async implementations to register Tasks / Threads to
+/// be woken up.
+#[derive(Debug)]
+pub struct Sleeper<T> {
+    /// Current Task / Thread to be woken up.
+    pub sleeper: Arc<T>,
+    /// mpsc Sender used to register Task / Thread.
+    pub sender: lockfree::channel::mpsc::Sender<Arc<T>>,
+}
+
+impl<T> Waker<T> {
+    /// Register all the Tasks / Threads sent for registration.
+    pub fn register_receivers(&mut self) {
+        for receiver in self.receiver.recv() {
+            self.sleepers.push(receiver);
+        }
+    }
+}
+
+/// Function used to create a ( Waker, Sleeper ) tuple.
+pub fn alarm<T>(current: T) -> (Waker<T>, Sleeper<T>) {
+    let mut vec = Vec::new();
+    let (sender, receiver) = lockfree::channel::mpsc::create();
+    let arc_t = Arc::new(current);
+    vec.push(arc_t.clone());
+    (
+        Waker {
+            sleepers: vec,
+            receiver,
+        },
+        Sleeper {
+            sleeper: arc_t,
+            sender,
+        },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    
+    #[test]
+    fn channel() {
+    }
+}


### PR DESCRIPTION
```rust
    
    let messages = vec![
        TopicPayload::new("numbers", 1u32),
        TopicPayload::new("strings", "FIRST"),
    ];
    let pub_task = stream::iter_ok(messages)
        .forward(publisher)
        .and_then(|(_, mut sink)| sink.close())
        .map(|_| ())
        .map_err(|_| ());
    
    rt.spawn(pub_task);
    
    let sub1 = subscriber.subscription("numbers");
    let numbers: Vec<u32> = rt.block_on(sub1.collect()).unwrap();
    assert_eq!(numbers.len(), 1);
    assert_eq!(numbers[0], 1);
    
    let sub2 = subscriber.subscription::<&str>("strings");
    let strings: Vec<_> = rt.block_on(sub2.collect()).unwrap();
    assert_eq!(strings.len(), 1);
    assert_eq!(strings[0], "FIRST");
    
    ```
